### PR TITLE
[FIX] Superposition leaderboard + match history

### DIFF
--- a/front-end/src/app/globals.css
+++ b/front-end/src/app/globals.css
@@ -255,6 +255,20 @@ body {
     font-weight: bold;
 }
 
+.matchHistory::-webkit-scrollbar {
+    width: 12px; /* Largeur de la scrollbar personnalisée */
+}
+
+.matchHistory::-webkit-scrollbar-thumb {
+    background-color: transparent; /* Couleur transparente pour le curseur de la scrollbar */
+    border: none; /* Supprime la bordure du curseur */
+}
+
+.matchHistory::-webkit-scrollbar-track {
+    background-color: transparent; /* Couleur transparente pour la piste de la scrollbar */
+    border: none; /* Supprime la bordure de la piste */
+}
+
 #match{
     width: auto;
     background: rgba(112, 112, 112, 0.27);

--- a/front-end/src/components/HomePageComponent.tsx
+++ b/front-end/src/components/HomePageComponent.tsx
@@ -43,7 +43,7 @@ const HomePage = () => {
         }
         localStorage.setItem('userContext', JSON.stringify(userContext));
 
-    })
+    });
 
     return (
         <>
@@ -53,8 +53,14 @@ const HomePage = () => {
                     <Profile className={"main-user-profile"}
                              user={userContext}
                              isEditable={true} avatarSize={"big"} showStats={true}>
-                        <Button image={"/history-list.svg"} onClick={() => setMatchHistoryVisible(!showMatchHistory)} alt={"Match History button"} title={"Match History"}/>
-                        <Button image={"/podium.svg"} onClick={() => setLeaderboardVisible(!showLeaderboard)} alt={"Leaderboard button"} title={"Leaderboard"} margin={"0 0 0 2ch"}/>
+                        <Button image={"/history-list.svg"} onClick={() => {
+                            setMatchHistoryVisible(!showMatchHistory);
+                            setLeaderboardVisible(false);
+                        }} alt={"Match History button"} title={"Match History"}/>
+                        <Button image={"/podium.svg"} onClick={() => {
+                            setLeaderboardVisible(!showLeaderboard);
+                            setMatchHistoryVisible(false);
+                        }} alt={"Leaderboard button"} title={"Leaderboard"} margin={"0 0 0 2ch"}/>
                         <Button2FA hasActive2FA={userContext.has_2fa}>2FA</Button2FA>
                     </Profile>
 


### PR DESCRIPTION
- Le leaderboard et l'historique des matchs se cachent quand on alterne entre l'un et l'autre.
- Scrollbar cachee pour le match history