### PR TITLE
fix "get bad request"

### DIFF
--- a/front-end/src/components/chat/subComponents/ChatChannelList.tsx
+++ b/front-end/src/components/chat/subComponents/ChatChannelList.tsx
@@ -199,7 +199,6 @@ useEffect(() => {
                       password: password
                     }
                     wsChatEvents.joinRoom(socket, joinChan)
-                    setCurrentChannel(channel.channelID);
                     setPopupChannelVisible(false);
                   }
                 }


### PR DESCRIPTION
Desactivation du auto join pour un chan Protected
car sinon il essaye dupdate les messages meme si mdp incorrect et on se prend une erreur 400